### PR TITLE
 Move global arrays to flash memory

### DIFF
--- a/LEGO-Dimensions.ino
+++ b/LEGO-Dimensions.ino
@@ -41,8 +41,8 @@ extern "C" {
 
 // If using the breakout or shield with I2C, define just the pins connected
 // to the IRQ and reset lines.  Use the values below (2, 3) for the shield!
-#define PN532_IRQ   (2)
-#define PN532_RESET (3)  // Not connected by default on the NFC Shield
+#define PN532_IRQ   (PB12)
+#define PN532_RESET (PB13)  // Not connected by default on the NFC Shield
 
 // Uncomment just _one_ line below depending on how your breakout or shield
 // is connected to the Arduino:
@@ -54,10 +54,10 @@ extern "C" {
 // the PN532 SCK, MOSI, and MISO pins need to be connected to the Arduino's
 // hardware SPI SCK, MOSI, and MISO pins.  On an Arduino Uno these are
 // SCK = 13, MOSI = 11, MISO = 12.  The SS line can be any digital IO pin.
-// Adafruit_PN532 nfc(PA4);
+Adafruit_PN532 nfc(PA4);
 
 // Or use this line for a breakout or shield with an I2C connection:
-Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
+// Adafruit_PN532 nfc(PN532_IRQ, PN532_RESET);
 
 void setup(void) {
   Serial.begin(115200);

--- a/characters.h
+++ b/characters.h
@@ -1,50 +1,99 @@
-static const char *legoCharacterStr[] = {
-	">null<",
-	"Batman",
-	"Gandalf",
-	"Wyldstyle",
-	"Aquaman",
-	"Bad Cop",
-	"Bane",
-	"Bart",
-	"Benny",
-	"Chell",
-	"Cole",
-	"Cragger",
-	"Cyborg",
-	"Cyberman",
-	"Doc Brown",
-	"The Doctor",
-	"Emmet",
-	"Eris",
-	"Gimli",
-	"Gollum",
-	"Harley Quinn",
-	"Homer",
-	"Jay",
-	"Joker",
-	"Kai",
-	"ACU",
-	"Gamer Kid",
-	"Krusty",
-	"Laval",
-	"Legolas",
-	"Lloyd",
-	"Marty Mcfly",
-	"Nya",
-	"Owen",
-	"Peter Venkman",
-	"Slimer",
-	"Scooby Doo",
-	"SenseiWu",
-	"Shaggy",
-	"Stay Puft",
-	"Superman",
-	"Unikitty",
-	"Wicked Witch",
-	"Superwoman",
-	"Zane",
-  "Green Arrow",
-  "Super Girl",
-  "Test 47"
+const char legoCharacter_01[] PROGMEM = ">null<";
+const char legoCharacter_02[] PROGMEM = "Batman";
+const char legoCharacter_03[] PROGMEM = "Gandalf";
+const char legoCharacter_04[] PROGMEM = "Wyldstyle";
+const char legoCharacter_05[] PROGMEM = "Aquaman";
+const char legoCharacter_06[] PROGMEM = "Bad Cop";
+const char legoCharacter_07[] PROGMEM = "Bane";
+const char legoCharacter_08[] PROGMEM = "Bart";
+const char legoCharacter_09[] PROGMEM = "Benny";
+const char legoCharacter_10[] PROGMEM = "Chell";
+const char legoCharacter_11[] PROGMEM = "Cole";
+const char legoCharacter_12[] PROGMEM = "Cragger";
+const char legoCharacter_13[] PROGMEM = "Cyborg";
+const char legoCharacter_14[] PROGMEM = "Cyberman";
+const char legoCharacter_15[] PROGMEM = "Doc Brown";
+const char legoCharacter_16[] PROGMEM = "The Doctor";
+const char legoCharacter_17[] PROGMEM = "Emmet";
+const char legoCharacter_18[] PROGMEM = "Eris";
+const char legoCharacter_19[] PROGMEM = "Gimli";
+const char legoCharacter_20[] PROGMEM = "Gollum";
+const char legoCharacter_21[] PROGMEM = "Harley Quinn";
+const char legoCharacter_22[] PROGMEM = "Homer";
+const char legoCharacter_23[] PROGMEM = "Jay";
+const char legoCharacter_24[] PROGMEM = "Joker";
+const char legoCharacter_25[] PROGMEM = "Kai";
+const char legoCharacter_26[] PROGMEM = "ACU";
+const char legoCharacter_27[] PROGMEM = "Gamer Kid";
+const char legoCharacter_28[] PROGMEM = "Krusty";
+const char legoCharacter_29[] PROGMEM = "Laval";
+const char legoCharacter_30[] PROGMEM = "Legolas";
+const char legoCharacter_31[] PROGMEM = "Lloyd";
+const char legoCharacter_32[] PROGMEM = "Marty Mcfly";
+const char legoCharacter_33[] PROGMEM = "Nya";
+const char legoCharacter_34[] PROGMEM = "Owen";
+const char legoCharacter_35[] PROGMEM = "Peter Venkman";
+const char legoCharacter_36[] PROGMEM = "Slimer";
+const char legoCharacter_37[] PROGMEM = "Scooby Doo";
+const char legoCharacter_38[] PROGMEM = "SenseiWu";
+const char legoCharacter_39[] PROGMEM = "Shaggy";
+const char legoCharacter_40[] PROGMEM = "Stay Puft";
+const char legoCharacter_41[] PROGMEM = "Superman";
+const char legoCharacter_42[] PROGMEM = "Unikitty";
+const char legoCharacter_43[] PROGMEM = "Wicked Witch";
+const char legoCharacter_44[] PROGMEM = "Superwoman";
+const char legoCharacter_45[] PROGMEM = "Zane";
+const char legoCharacter_46[] PROGMEM = "Green Arrow";
+const char legoCharacter_47[] PROGMEM = "Super Girl";
+const char legoCharacter_48[] PROGMEM = "Test 47";
+
+static const char* const legoCharacterStr[] PROGMEM = {
+	legoCharacter_01,
+	legoCharacter_02,
+	legoCharacter_03,
+	legoCharacter_04,
+	legoCharacter_05,
+	legoCharacter_06,
+	legoCharacter_07,
+	legoCharacter_08,
+	legoCharacter_09,
+	legoCharacter_10,
+	legoCharacter_11,
+	legoCharacter_12,
+	legoCharacter_13,
+	legoCharacter_14,
+	legoCharacter_15,
+	legoCharacter_16,
+	legoCharacter_17,
+	legoCharacter_18,
+	legoCharacter_19,
+	legoCharacter_20,
+	legoCharacter_21,
+	legoCharacter_22,
+	legoCharacter_23,
+	legoCharacter_24,
+	legoCharacter_25,
+	legoCharacter_26,
+	legoCharacter_27,
+	legoCharacter_28,
+	legoCharacter_29,
+	legoCharacter_30,
+	legoCharacter_31,
+	legoCharacter_32,
+	legoCharacter_33,
+	legoCharacter_34,
+	legoCharacter_35,
+	legoCharacter_36,
+	legoCharacter_37,
+	legoCharacter_38,
+	legoCharacter_39,
+	legoCharacter_40,
+	legoCharacter_41,
+	legoCharacter_42,
+	legoCharacter_43,
+	legoCharacter_44,
+	legoCharacter_45,
+	legoCharacter_46,
+	legoCharacter_47,
+	legoCharacter_48,
 };

--- a/vehicles_and_gadgets.h
+++ b/vehicles_and_gadgets.h
@@ -1,172 +1,343 @@
-static const char *legoVehicleStr[] = {
-	"Police Car",
-	"Aerial Squad Car",
-	"Missile Striker",
-	"Gravity Sprinter",
-	"Street Shredder",
-	"Sky Clobberer",
-	"Batmobile",
-	"Batblaster",
-	"Sonic Batray",
-	"Benny's Spaceship",
-	"Lasercraft",
-	"The Annihilator",
-	"Delorean",
-	"Ultra Time Machine",
-	"Electric Time Machine",
-	"Hoverboard",
-	"Cyclone Board",
-	"Ultimate Hoverjet",
-	"Eagle interceptor",
-	"Eagle Skyblazer",
-	"Eagle Swoop Diver",
-	"Cragger's Fireship",
-	"Croc Command Sub",
-	"Swamp Skimmer",
-	"Cyber Guard",
-	"Cyber-Wrecker",
-	"Laser Robot Walker",
-	"K9",
-	"K9 Ruff Rover",
-	"K9 Laser Cutter",
-	"TARDIS",
-	"Laser-Pulse TARDIS",
-	"Energy-Burst TARDIS",
-	"Emmet's Excavator",
-	"The Destroydozer",
-	"Destruct-o-Mech",
-	"Winged Monkey",
-	"Battle Monkey",
-	"Commander Monkey",
-	"Axe Chariot",
-	"Axe Hurler",
-	"Soaring Chariot",
-	"Shelob the Great",
-	"8-Legged Stalker",
-	"Poison Slinger",
-	"Homer's Car",
-	"Homercraft",
-	"SubmaHomer",
-	"Taunt-o-Vision",
-	"Blast Cam",
-	"The MechaHomer",
-	"Velociraptor",
-	"Spike Attack Raptor",
-	"Venom Raptor",
-	"Gyro Sphere",
-	"Sonic Beam Gyrosphere",
-	"Speed Boost Gyrosphere",
-	"Clown Bike",
-	"Cannon Bike",
-	"Anti-Gravity Rocket Bike",
-	"Mighty Lion Rider",
-	"Lion Blazer",
-	"Fire Lion",
-	"Arrow Launcher",
-	"Seeking Shooter",
-	"Triple Ballista",
-	"Mystery Machine",
-	"Mystery Tow",
-	"Mystery Monster",
-	"Boulder Bomber",
-	"Boulder Blaster",
-	"Cyclone Jet",
-	"Storm Fighter",
-	"Lightning Jet",
-	"Electro-Shooter",
-	"Blade Bike",
-	"Flying Fire Bike",
-	"Blades of Fire",
-	"Samurai Mech",
-	"Samurai Shooter",
-	"Soaring Samurai Mech",
-	"Companion Cube",
-	"Laser Deflector",
-	"Gold Heart Emitter",
-	"Sentry Turret",
-	"Turret Striker",
-	"Flying Turret Carrier",
-	"Scooby Snack",
-	"Scooby Fire Snack",
-	"Scooby Ghost Snack",
-	"Cloud Cukko Car",
-	"X-Stream Soaker",
-	"Rainbow Cannon",
-	"Invisible Jet",
-	"Stealth Laser Shooter",
-	"Torpedo Bomber",
-	"Ninja Copter",
-	"Glaciator",
-	"Freeze Fighter",
-	"Traveling Time Train",
-	"(Traveling Time Train - rebuilt 1)",
-	"(Traveling Time Train - rebuilt 2)",
-	"Aqua Watercraft",
-	"(Aqua Watercraft - rebuilt 1)",
-	"(Aqua Watercraft - rebuilt 2)",
-	"Drill Driver",
-	"(Drill Driver - rebuilt 1)",
-	"(Drill Driver - rebuilt 2)",
-	"Quinn-mobile",
-	"(Quinn-mobile - rebuilt 1)",
-	"(Quinn-mobile - rebuilt 2)",
-	"The Jokers Chopper",
-	"(The Jokers Chopper - rebuilt 1)",
-	"(The Jokers Chopper - rebuilt 2)",
-	"Hover Pod",
-	"(Hover Pod - rebuilt 1)",
-	"(Hover Pod - rebuilt 2)",
-	"Dalek",
-	"(Dalek - rebuilt 1)",
-	"(Dalek - rebuilt 2)",
-	"Ecto-1",
-	"(Ecto-1 - rebuilt 1)",
-	"(Ecto-1 - rebuilt 2)",
-	"Ghost Trap",
-	"(Ghost Trap - rebuilt 1)",
-	"(Ghost Trap - rebuilt 2)",
-	"unknown",
-	"unknown",
-	"unknown",
-	"unknown",
-	"unknown",
-	"unknown",
-	"Llyod's Golden Dragon",
-	"(Golden Dragon - rebuilt 1)",
-	"(Golden Dragon - rebuilt 2)",
-	"unknown",
-	"unknown",
-	"unknown",
-	"unknown",
-	"unknown",
-	"unknown",
-	"unknown",
-	"unknown",
-	"unknown",
-	"Mega Flight Dragon",
-	"(Mega Flight Dragon - rebuilt 1)",
-	"(Mega Flight Dragon - rebuilt 2)",
-	"unknown",
-	"unknown",
-	"unknown",
-	"unknown",
-	"unknown",
-	"unknown",
-	"unknown",
-	"unknown",
-	"Flying White Dragon",
-	"Golden Fire Dragon",
-	"Ultra Destruction Dragon",
-	"Arcade Machine",
-	"8-bit Shooter",
-	"The Pixelator",
-	"G-61555 Spy Hunter",
-	"The Interdiver",
-	"Aerial Spyhunter",
-	"Slime Shooter",
-	"Slime Exploder",
-	"Slime Streamer",
-	"Terror Dog",
-	"Terror Dog Destroyer",
-	"Soaring Terror Dog"
+const char legoVehicle_001[] PROGMEM = "Police Car";
+const char legoVehicle_002[] PROGMEM = "Aerial Squad Car";
+const char legoVehicle_003[] PROGMEM = "Missile Striker";
+const char legoVehicle_004[] PROGMEM = "Gravity Sprinter";
+const char legoVehicle_005[] PROGMEM = "Street Shredder";
+const char legoVehicle_006[] PROGMEM = "Sky Clobberer";
+const char legoVehicle_007[] PROGMEM = "Batmobile";
+const char legoVehicle_008[] PROGMEM = "Batblaster";
+const char legoVehicle_009[] PROGMEM = "Sonic Batray";
+const char legoVehicle_010[] PROGMEM = "Benny's Spaceship";
+const char legoVehicle_011[] PROGMEM = "Lasercraft";
+const char legoVehicle_012[] PROGMEM = "The Annihilator";
+const char legoVehicle_013[] PROGMEM = "Delorean";
+const char legoVehicle_014[] PROGMEM = "Ultra Time Machine";
+const char legoVehicle_015[] PROGMEM = "Electric Time Machine";
+const char legoVehicle_016[] PROGMEM = "Hoverboard";
+const char legoVehicle_017[] PROGMEM = "Cyclone Board";
+const char legoVehicle_018[] PROGMEM = "Ultimate Hoverjet";
+const char legoVehicle_019[] PROGMEM = "Eagle interceptor";
+const char legoVehicle_020[] PROGMEM = "Eagle Skyblazer";
+const char legoVehicle_021[] PROGMEM = "Eagle Swoop Diver";
+const char legoVehicle_022[] PROGMEM = "Cragger's Fireship";
+const char legoVehicle_023[] PROGMEM = "Croc Command Sub";
+const char legoVehicle_024[] PROGMEM = "Swamp Skimmer";
+const char legoVehicle_025[] PROGMEM = "Cyber Guard";
+const char legoVehicle_026[] PROGMEM = "Cyber-Wrecker";
+const char legoVehicle_027[] PROGMEM = "Laser Robot Walker";
+const char legoVehicle_028[] PROGMEM = "K9";
+const char legoVehicle_029[] PROGMEM = "K9 Ruff Rover";
+const char legoVehicle_030[] PROGMEM = "K9 Laser Cutter";
+const char legoVehicle_031[] PROGMEM = "TARDIS";
+const char legoVehicle_032[] PROGMEM = "Laser-Pulse TARDIS";
+const char legoVehicle_033[] PROGMEM = "Energy-Burst TARDIS";
+const char legoVehicle_034[] PROGMEM = "Emmet's Excavator";
+const char legoVehicle_035[] PROGMEM = "The Destroydozer";
+const char legoVehicle_036[] PROGMEM = "Destruct-o-Mech";
+const char legoVehicle_037[] PROGMEM = "Winged Monkey";
+const char legoVehicle_038[] PROGMEM = "Battle Monkey";
+const char legoVehicle_039[] PROGMEM = "Commander Monkey";
+const char legoVehicle_040[] PROGMEM = "Axe Chariot";
+const char legoVehicle_041[] PROGMEM = "Axe Hurler";
+const char legoVehicle_042[] PROGMEM = "Soaring Chariot";
+const char legoVehicle_043[] PROGMEM = "Shelob the Great";
+const char legoVehicle_044[] PROGMEM = "8-Legged Stalker";
+const char legoVehicle_045[] PROGMEM = "Poison Slinger";
+const char legoVehicle_046[] PROGMEM = "Homer's Car";
+const char legoVehicle_047[] PROGMEM = "Homercraft";
+const char legoVehicle_048[] PROGMEM = "SubmaHomer";
+const char legoVehicle_049[] PROGMEM = "Taunt-o-Vision";
+const char legoVehicle_050[] PROGMEM = "Blast Cam";
+const char legoVehicle_051[] PROGMEM = "The MechaHomer";
+const char legoVehicle_052[] PROGMEM = "Velociraptor";
+const char legoVehicle_053[] PROGMEM = "Spike Attack Raptor";
+const char legoVehicle_054[] PROGMEM = "Venom Raptor";
+const char legoVehicle_055[] PROGMEM = "Gyro Sphere";
+const char legoVehicle_056[] PROGMEM = "Sonic Beam Gyrosphere";
+const char legoVehicle_057[] PROGMEM = "Speed Boost Gyrosphere";
+const char legoVehicle_058[] PROGMEM = "Clown Bike";
+const char legoVehicle_059[] PROGMEM = "Cannon Bike";
+const char legoVehicle_060[] PROGMEM = "Anti-Gravity Rocket Bike";
+const char legoVehicle_061[] PROGMEM = "Mighty Lion Rider";
+const char legoVehicle_062[] PROGMEM = "Lion Blazer";
+const char legoVehicle_063[] PROGMEM = "Fire Lion";
+const char legoVehicle_064[] PROGMEM = "Arrow Launcher";
+const char legoVehicle_065[] PROGMEM = "Seeking Shooter";
+const char legoVehicle_066[] PROGMEM = "Triple Ballista";
+const char legoVehicle_067[] PROGMEM = "Mystery Machine";
+const char legoVehicle_068[] PROGMEM = "Mystery Tow";
+const char legoVehicle_069[] PROGMEM = "Mystery Monster";
+const char legoVehicle_070[] PROGMEM = "Boulder Bomber";
+const char legoVehicle_071[] PROGMEM = "Boulder Blaster";
+const char legoVehicle_072[] PROGMEM = "Cyclone Jet";
+const char legoVehicle_073[] PROGMEM = "Storm Fighter";
+const char legoVehicle_074[] PROGMEM = "Lightning Jet";
+const char legoVehicle_075[] PROGMEM = "Electro-Shooter";
+const char legoVehicle_076[] PROGMEM = "Blade Bike";
+const char legoVehicle_077[] PROGMEM = "Flying Fire Bike";
+const char legoVehicle_078[] PROGMEM = "Blades of Fire";
+const char legoVehicle_079[] PROGMEM = "Samurai Mech";
+const char legoVehicle_080[] PROGMEM = "Samurai Shooter";
+const char legoVehicle_081[] PROGMEM = "Soaring Samurai Mech";
+const char legoVehicle_082[] PROGMEM = "Companion Cube";
+const char legoVehicle_083[] PROGMEM = "Laser Deflector";
+const char legoVehicle_084[] PROGMEM = "Gold Heart Emitter";
+const char legoVehicle_085[] PROGMEM = "Sentry Turret";
+const char legoVehicle_086[] PROGMEM = "Turret Striker";
+const char legoVehicle_087[] PROGMEM = "Flying Turret Carrier";
+const char legoVehicle_088[] PROGMEM = "Scooby Snack";
+const char legoVehicle_089[] PROGMEM = "Scooby Fire Snack";
+const char legoVehicle_090[] PROGMEM = "Scooby Ghost Snack";
+const char legoVehicle_091[] PROGMEM = "Cloud Cukko Car";
+const char legoVehicle_092[] PROGMEM = "X-Stream Soaker";
+const char legoVehicle_093[] PROGMEM = "Rainbow Cannon";
+const char legoVehicle_094[] PROGMEM = "Invisible Jet";
+const char legoVehicle_095[] PROGMEM = "Stealth Laser Shooter";
+const char legoVehicle_096[] PROGMEM = "Torpedo Bomber";
+const char legoVehicle_097[] PROGMEM = "Ninja Copter";
+const char legoVehicle_098[] PROGMEM = "Glaciator";
+const char legoVehicle_099[] PROGMEM = "Freeze Fighter";
+const char legoVehicle_100[] PROGMEM = "Traveling Time Train";
+const char legoVehicle_101[] PROGMEM = "(Traveling Time Train - rebuilt 1)";
+const char legoVehicle_102[] PROGMEM = "(Traveling Time Train - rebuilt 2)";
+const char legoVehicle_103[] PROGMEM = "Aqua Watercraft";
+const char legoVehicle_104[] PROGMEM = "(Aqua Watercraft - rebuilt 1)";
+const char legoVehicle_105[] PROGMEM = "(Aqua Watercraft - rebuilt 2)";
+const char legoVehicle_106[] PROGMEM = "Drill Driver";
+const char legoVehicle_107[] PROGMEM = "(Drill Driver - rebuilt 1)";
+const char legoVehicle_108[] PROGMEM = "(Drill Driver - rebuilt 2)";
+const char legoVehicle_109[] PROGMEM = "Quinn-mobile";
+const char legoVehicle_110[] PROGMEM = "(Quinn-mobile - rebuilt 1)";
+const char legoVehicle_111[] PROGMEM = "(Quinn-mobile - rebuilt 2)";
+const char legoVehicle_112[] PROGMEM = "The Jokers Chopper";
+const char legoVehicle_113[] PROGMEM = "(The Jokers Chopper - rebuilt 1)";
+const char legoVehicle_114[] PROGMEM = "(The Jokers Chopper - rebuilt 2)";
+const char legoVehicle_115[] PROGMEM = "Hover Pod";
+const char legoVehicle_116[] PROGMEM = "(Hover Pod - rebuilt 1)";
+const char legoVehicle_117[] PROGMEM = "(Hover Pod - rebuilt 2)";
+const char legoVehicle_118[] PROGMEM = "Dalek";
+const char legoVehicle_119[] PROGMEM = "(Dalek - rebuilt 1)";
+const char legoVehicle_120[] PROGMEM = "(Dalek - rebuilt 2)";
+const char legoVehicle_121[] PROGMEM = "Ecto-1";
+const char legoVehicle_122[] PROGMEM = "(Ecto-1 - rebuilt 1)";
+const char legoVehicle_123[] PROGMEM = "(Ecto-1 - rebuilt 2)";
+const char legoVehicle_124[] PROGMEM = "Ghost Trap";
+const char legoVehicle_125[] PROGMEM = "(Ghost Trap - rebuilt 1)";
+const char legoVehicle_126[] PROGMEM = "(Ghost Trap - rebuilt 2)";
+const char legoVehicle_127[] PROGMEM = "unknown";
+const char legoVehicle_128[] PROGMEM = "unknown";
+const char legoVehicle_129[] PROGMEM = "unknown";
+const char legoVehicle_130[] PROGMEM = "unknown";
+const char legoVehicle_131[] PROGMEM = "unknown";
+const char legoVehicle_132[] PROGMEM = "unknown";
+const char legoVehicle_133[] PROGMEM = "Llyod's Golden Dragon";
+const char legoVehicle_134[] PROGMEM = "(Golden Dragon - rebuilt 1)";
+const char legoVehicle_135[] PROGMEM = "(Golden Dragon - rebuilt 2)";
+const char legoVehicle_136[] PROGMEM = "unknown";
+const char legoVehicle_137[] PROGMEM = "unknown";
+const char legoVehicle_138[] PROGMEM = "unknown";
+const char legoVehicle_139[] PROGMEM = "unknown";
+const char legoVehicle_140[] PROGMEM = "unknown";
+const char legoVehicle_141[] PROGMEM = "unknown";
+const char legoVehicle_142[] PROGMEM = "unknown";
+const char legoVehicle_143[] PROGMEM = "unknown";
+const char legoVehicle_144[] PROGMEM = "unknown";
+const char legoVehicle_145[] PROGMEM = "Mega Flight Dragon";
+const char legoVehicle_146[] PROGMEM = "(Mega Flight Dragon - rebuilt 1)";
+const char legoVehicle_147[] PROGMEM = "(Mega Flight Dragon - rebuilt 2)";
+const char legoVehicle_148[] PROGMEM = "unknown";
+const char legoVehicle_149[] PROGMEM = "unknown";
+const char legoVehicle_150[] PROGMEM = "unknown";
+const char legoVehicle_151[] PROGMEM = "unknown";
+const char legoVehicle_152[] PROGMEM = "unknown";
+const char legoVehicle_153[] PROGMEM = "unknown";
+const char legoVehicle_154[] PROGMEM = "unknown";
+const char legoVehicle_155[] PROGMEM = "unknown";
+const char legoVehicle_156[] PROGMEM = "Flying White Dragon";
+const char legoVehicle_157[] PROGMEM = "Golden Fire Dragon";
+const char legoVehicle_158[] PROGMEM = "Ultra Destruction Dragon";
+const char legoVehicle_159[] PROGMEM = "Arcade Machine";
+const char legoVehicle_160[] PROGMEM = "8-bit Shooter";
+const char legoVehicle_161[] PROGMEM = "The Pixelator";
+const char legoVehicle_162[] PROGMEM = "G-61555 Spy Hunter";
+const char legoVehicle_163[] PROGMEM = "The Interdiver";
+const char legoVehicle_164[] PROGMEM = "Aerial Spyhunter";
+const char legoVehicle_165[] PROGMEM = "Slime Shooter";
+const char legoVehicle_166[] PROGMEM = "Slime Exploder";
+const char legoVehicle_167[] PROGMEM = "Slime Streamer";
+const char legoVehicle_168[] PROGMEM = "Terror Dog";
+const char legoVehicle_169[] PROGMEM = "Terror Dog Destroyer";
+const char legoVehicle_170[] PROGMEM = "Soaring Terror Dog";
+
+static const char* const legoVehicleStr[] PROGMEM = {
+	legoVehicle_001,
+	legoVehicle_002,
+	legoVehicle_003,
+	legoVehicle_004,
+	legoVehicle_005,
+	legoVehicle_006,
+	legoVehicle_007,
+	legoVehicle_008,
+	legoVehicle_009,
+	legoVehicle_010,
+	legoVehicle_011,
+	legoVehicle_012,
+	legoVehicle_013,
+	legoVehicle_014,
+	legoVehicle_015,
+	legoVehicle_016,
+	legoVehicle_017,
+	legoVehicle_018,
+	legoVehicle_019,
+	legoVehicle_020,
+	legoVehicle_021,
+	legoVehicle_022,
+	legoVehicle_023,
+	legoVehicle_024,
+	legoVehicle_025,
+	legoVehicle_026,
+	legoVehicle_027,
+	legoVehicle_028,
+	legoVehicle_029,
+	legoVehicle_030,
+	legoVehicle_031,
+	legoVehicle_032,
+	legoVehicle_033,
+	legoVehicle_034,
+	legoVehicle_035,
+	legoVehicle_036,
+	legoVehicle_037,
+	legoVehicle_038,
+	legoVehicle_039,
+	legoVehicle_040,
+	legoVehicle_041,
+	legoVehicle_042,
+	legoVehicle_043,
+	legoVehicle_044,
+	legoVehicle_045,
+	legoVehicle_046,
+	legoVehicle_047,
+	legoVehicle_048,
+	legoVehicle_049,
+	legoVehicle_050,
+	legoVehicle_051,
+	legoVehicle_052,
+	legoVehicle_053,
+	legoVehicle_054,
+	legoVehicle_055,
+	legoVehicle_056,
+	legoVehicle_057,
+	legoVehicle_058,
+	legoVehicle_059,
+	legoVehicle_060,
+	legoVehicle_061,
+	legoVehicle_062,
+	legoVehicle_063,
+	legoVehicle_064,
+	legoVehicle_065,
+	legoVehicle_066,
+	legoVehicle_067,
+	legoVehicle_068,
+	legoVehicle_069,
+	legoVehicle_070,
+	legoVehicle_071,
+	legoVehicle_072,
+	legoVehicle_073,
+	legoVehicle_074,
+	legoVehicle_075,
+	legoVehicle_076,
+	legoVehicle_077,
+	legoVehicle_078,
+	legoVehicle_079,
+	legoVehicle_080,
+	legoVehicle_081,
+	legoVehicle_082,
+	legoVehicle_083,
+	legoVehicle_084,
+	legoVehicle_085,
+	legoVehicle_086,
+	legoVehicle_087,
+	legoVehicle_088,
+	legoVehicle_089,
+	legoVehicle_090,
+	legoVehicle_091,
+	legoVehicle_092,
+	legoVehicle_093,
+	legoVehicle_094,
+	legoVehicle_095,
+	legoVehicle_096,
+	legoVehicle_097,
+	legoVehicle_098,
+	legoVehicle_099,
+	legoVehicle_100,
+	legoVehicle_101,
+	legoVehicle_102,
+	legoVehicle_103,
+	legoVehicle_104,
+	legoVehicle_105,
+	legoVehicle_106,
+	legoVehicle_107,
+	legoVehicle_108,
+	legoVehicle_109,
+	legoVehicle_110,
+	legoVehicle_111,
+	legoVehicle_112,
+	legoVehicle_113,
+	legoVehicle_114,
+	legoVehicle_115,
+	legoVehicle_116,
+	legoVehicle_117,
+	legoVehicle_118,
+	legoVehicle_119,
+	legoVehicle_120,
+	legoVehicle_121,
+	legoVehicle_122,
+	legoVehicle_123,
+	legoVehicle_124,
+	legoVehicle_125,
+	legoVehicle_126,
+	legoVehicle_127,
+	legoVehicle_128,
+	legoVehicle_129,
+	legoVehicle_130,
+	legoVehicle_131,
+	legoVehicle_132,
+	legoVehicle_133,
+	legoVehicle_134,
+	legoVehicle_135,
+	legoVehicle_136,
+	legoVehicle_137,
+	legoVehicle_138,
+	legoVehicle_139,
+	legoVehicle_140,
+	legoVehicle_141,
+	legoVehicle_142,
+	legoVehicle_143,
+	legoVehicle_144,
+	legoVehicle_145,
+	legoVehicle_146,
+	legoVehicle_147,
+	legoVehicle_148,
+	legoVehicle_149,
+	legoVehicle_150,
+	legoVehicle_151,
+	legoVehicle_152,
+	legoVehicle_153,
+	legoVehicle_154,
+	legoVehicle_155,
+	legoVehicle_156,
+	legoVehicle_157,
+	legoVehicle_158,
+	legoVehicle_159,
+	legoVehicle_160,
+	legoVehicle_161,
+	legoVehicle_162,
+	legoVehicle_163,
+	legoVehicle_164,
+	legoVehicle_165,
+	legoVehicle_166,
+	legoVehicle_167,
+	legoVehicle_168,
+	legoVehicle_169,
+	legoVehicle_170,
 };


### PR DESCRIPTION
Move legoCharacter & legoVehicle to progmem.
This allow more space for global variable and now can be compiled on ATmega328 chips.

`Global variables use 927 bytes (45%) of dynamic memory, leaving 1121 bytes for local variables. Maximum is 2048 bytes.`

closes #1 